### PR TITLE
Add Scala 3 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.6, 2.12.14]
+        scala: [2.13.6, 2.12.14, 3.0.1]
         java: [adopt@1.8, adopt@1.11]
     runs-on: ${{ matrix.os }}
     steps:
@@ -116,6 +116,16 @@ jobs:
           name: target-${{ matrix.os }}-2.12.14-${{ matrix.java }}
 
       - name: Inflate target directories (2.12.14)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (3.0.1)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-3.0.1-${{ matrix.java }}
+
+      - name: Inflate target directories (3.0.1)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/ci-release.sbt
+++ b/ci-release.sbt
@@ -1,5 +1,9 @@
 ThisBuild / scalaVersion := Dependencies.Versions.scala213
-ThisBuild / crossScalaVersions := Seq(Dependencies.Versions.scala213, Dependencies.Versions.scala212)
+ThisBuild / crossScalaVersions := Seq(
+  Dependencies.Versions.scala213,
+  Dependencies.Versions.scala212,
+  Dependencies.Versions.scala3
+)
 ThisBuild / githubWorkflowTargetTags ++= Seq("v*")
 ThisBuild / githubWorkflowJavaVersions := Seq("adopt@1.8", "adopt@1.11")
 

--- a/modules/jaeger-integration-test/src/main/scala/io/janstenpickle/trace4cats/test/jaeger/JaegerModel.scala
+++ b/modules/jaeger-integration-test/src/main/scala/io/janstenpickle/trace4cats/test/jaeger/JaegerModel.scala
@@ -2,7 +2,6 @@ package io.janstenpickle.trace4cats.test.jaeger
 
 import cats.data.NonEmptyList
 import io.circe.{Decoder, DecodingFailure}
-import io.circe.generic.auto._
 import io.circe.generic.semiauto._
 
 case class JaegerTraceResponse(data: NonEmptyList[JaegerTrace])
@@ -64,3 +63,7 @@ object JaegerTag {
 }
 
 case class JaegerReference(refType: String, traceID: String, spanID: String)
+
+object JaegerReference {
+  implicit val decoder: Decoder[JaegerReference] = deriveDecoder
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
     val scala213 = "2.13.6"
     val scala3 = "3.0.1"
 
-    val trace4cats = "0.12.0-RC2"
+    val trace4cats = "0.12.0-RC2+17-d73c7ff3"
 
     val circe = "0.14.1"
     val http4s = "0.23.0-RC1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,6 +4,7 @@ object Dependencies {
   object Versions {
     val scala212 = "2.12.14"
     val scala213 = "2.13.6"
+    val scala3 = "3.0.1"
 
     val trace4cats = "0.12.0-RC2"
 
@@ -18,10 +19,10 @@ object Dependencies {
   lazy val trace4catsKernel = "io.janstenpickle"  %% "trace4cats-kernel"  % Versions.trace4cats
   lazy val trace4catsTestkit = "io.janstenpickle" %% "trace4cats-testkit" % Versions.trace4cats
 
-  lazy val circeGeneric = "io.circe"        %% "circe-generic-extras" % Versions.circe
-  lazy val http4sCirce = "org.http4s"       %% "http4s-circe"         % Versions.http4s
-  lazy val http4sBlazeClient = "org.http4s" %% "http4s-blaze-client"  % Versions.http4s
-  lazy val logback = "ch.qos.logback"        % "logback-classic"      % Versions.logback
+  lazy val circeGeneric = "io.circe"        %% "circe-generic"       % Versions.circe
+  lazy val http4sCirce = "org.http4s"       %% "http4s-circe"        % Versions.http4s
+  lazy val http4sBlazeClient = "org.http4s" %% "http4s-blaze-client" % Versions.http4s
+  lazy val logback = "ch.qos.logback"        % "logback-classic"     % Versions.logback
 
   lazy val kindProjector = ("org.typelevel" % "kind-projector"     % Versions.kindProjector).cross(CrossVersion.full)
   lazy val betterMonadicFor = "com.olegpy" %% "better-monadic-for" % Versions.betterMonadicFor


### PR DESCRIPTION
Usee circe-generic instead of generic-extras (which has no Scala 3 build). Requires a Scala 3-enabled build of trace4cats core components, see https://github.com/trace4cats/trace4cats/pull/587