### PR TITLE
Preserve time precision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.8, 2.12.16, 3.1.3]
+        scala: [2.13.11, 2.12.18, 3.3.0]
         java: [temurin@8, temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -83,7 +83,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.8]
+        scala: [2.13.11]
         java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -118,32 +118,32 @@ jobs:
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
-      - name: Download target directories (2.13.8)
+      - name: Download target directories (2.13.11)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-2.13.8-${{ matrix.java }}
+          name: target-${{ matrix.os }}-2.13.11-${{ matrix.java }}
 
-      - name: Inflate target directories (2.13.8)
+      - name: Inflate target directories (2.13.11)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (2.12.16)
+      - name: Download target directories (2.12.18)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-2.12.16-${{ matrix.java }}
+          name: target-${{ matrix.os }}-2.12.18-${{ matrix.java }}
 
-      - name: Inflate target directories (2.12.16)
+      - name: Inflate target directories (2.12.18)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (3.1.3)
+      - name: Download target directories (3.3.0)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-3.1.3-${{ matrix.java }}
+          name: target-${{ matrix.os }}-3.3.0-${{ matrix.java }}
 
-      - name: Inflate target directories (3.1.3)
+      - name: Inflate target directories (3.3.0)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ lazy val commonSettings = Seq(
     }
   },
   Test / fork := true,
-  resolvers += Resolver.sonatypeRepo("releases"),
+  resolvers ++= Resolver.sonatypeOssRepos("releases"),
 )
 
 lazy val noPublishSettings =

--- a/modules/jaeger-integration-test/src/main/scala/trace4cats/test/jaeger/BaseJaegerSpec.scala
+++ b/modules/jaeger-integration-test/src/main/scala/trace4cats/test/jaeger/BaseJaegerSpec.scala
@@ -1,7 +1,6 @@
 package trace4cats.test.jaeger
 
 import java.util.concurrent.TimeUnit
-
 import cats.data.NonEmptyList
 import cats.effect.unsafe.implicits.global
 import cats.effect.{IO, Resource}
@@ -18,6 +17,8 @@ import trace4cats.kernel.{SpanCompleter, SpanExporter}
 import trace4cats.model._
 import trace4cats.test.ArbitraryInstances
 
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 import scala.concurrent.duration._
 
 trait BaseJaegerSpec extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks with ArbitraryInstances {
@@ -77,13 +78,15 @@ trait BaseJaegerSpec extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks wit
                       case _ => List.empty[JaegerReference]
                     }
 
+                    val startMicros = ChronoUnit.MICROS.between(Instant.EPOCH, span.start)
+                    val durationMicros = ChronoUnit.MICROS.between(span.start, span.end)
+
                     JaegerSpan(
                       traceID = traceId.show,
                       spanID = span.context.spanId.show,
                       operationName = span.name,
-                      startTime = TimeUnit.MILLISECONDS.toMicros(span.start.toEpochMilli),
-                      duration = TimeUnit.MILLISECONDS.toMicros(span.end.toEpochMilli) - TimeUnit.MILLISECONDS
-                        .toMicros(span.start.toEpochMilli),
+                      startTime = startMicros,
+                      duration = durationMicros,
                       tags = jtags,
                       references = (parentRefs ++ linkRefs).sortBy(_.traceID)
                     )

--- a/modules/jaeger-integration-test/src/main/scala/trace4cats/test/jaeger/BaseJaegerSpec.scala
+++ b/modules/jaeger-integration-test/src/main/scala/trace4cats/test/jaeger/BaseJaegerSpec.scala
@@ -1,6 +1,7 @@
 package trace4cats.test.jaeger
 
-import java.util.concurrent.TimeUnit
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 import cats.data.NonEmptyList
 import cats.effect.unsafe.implicits.global
 import cats.effect.{IO, Resource}
@@ -17,8 +18,6 @@ import trace4cats.kernel.{SpanCompleter, SpanExporter}
 import trace4cats.model._
 import trace4cats.test.ArbitraryInstances
 
-import java.time.Instant
-import java.time.temporal.ChronoUnit
 import scala.concurrent.duration._
 
 trait BaseJaegerSpec extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks with ArbitraryInstances {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,18 +2,18 @@ import sbt._
 
 object Dependencies {
   object Versions {
-    val scala212 = "2.12.16"
-    val scala213 = "2.13.8"
-    val scala3 = "3.1.3"
+    val scala212 = "2.12.18"
+    val scala213 = "2.13.11"
+    val scala3 = "3.3.0"
 
-    val trace4cats = "0.14.0"
+    val trace4cats = "0.14.2"
 
-    val circe = "0.14.2"
-    val http4s = "0.23.14"
+    val circe = "0.14.5"
+    val http4s = "0.23.21"
 
-    val http4sBlaze = "0.23.12"
+    val http4sBlaze = "0.23.15"
 
-    val logback = "1.2.12"
+    val logback = "1.4.8"
 
     val kindProjector = "0.13.2"
     val betterMonadicFor = "0.3.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
     val scala213 = "2.13.11"
     val scala3 = "3.3.0"
 
-    val trace4cats = "0.14.2"
+    val trace4cats = "0.14.3"
 
     val circe = "0.14.5"
     val http4s = "0.23.21"


### PR DESCRIPTION
As we have more precise time data from cats effect 3.4+, make sure to not truncate it to millis.

Should fix the test failure in https://github.com/trace4cats/trace4cats-jaeger/pull/175