### PR TITLE
Downgrade logback to 1.2.12 to stay on slf4j 1.x

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
 
     val http4sBlaze = "0.23.15"
 
-    val logback = "1.3.8"
+    val logback = "1.2.12"
 
     val kindProjector = "0.13.2"
     val betterMonadicFor = "0.3.1"


### PR DESCRIPTION
Avoid version collisions downstream as most Scala libs are still on 1.x